### PR TITLE
Fix ESM (module) path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "trailingComma": "es5"
   },
   "author": "Zach Silveira",
-  "module": "dist/@zach.codes/react-calendar.esm.js",
+  "module": "dist/react-calendar.esm.js",
   "size-limit": [
     {
-      "path": "dist/@zach.codes/react-calendar.cjs.production.min.js",
+      "path": "dist/react-calendar.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/@zach.codes/react-calendar.esm.js",
+      "path": "dist/react-calendar.esm.js",
       "limit": "10 KB"
     }
   ],


### PR DESCRIPTION
Modified `module` path to be correct so ESM-enabled bundlers can properly resolve the output ES module.